### PR TITLE
Fleshed out react component wrappers

### DIFF
--- a/open_widget_sample_app/settings.py
+++ b/open_widget_sample_app/settings.py
@@ -151,7 +151,5 @@ WEBPACK_LOADER = {
 CORS_ORIGIN_ALLOW_ALL = True
 
 WIDGET_FRAMEWORK = {
-    'WIDGET_FRAMEWORK_AUTHENTICATION_CLASSES': (BasicAuthentication,),
-    'WIDGET_FRAMEWORK_PERMISSION_CLASSES': (DjangoObjectPermissions,),
-    'WIDGET_LIST_EDIT_PERMISSIONS': ['change_widgetlist']
+    # 'WIDGET_LIST_EDIT_PERMISSIONS': ['change_widgetlist']
 }

--- a/open_widget_sample_app/settings.py
+++ b/open_widget_sample_app/settings.py
@@ -11,6 +11,8 @@ https://docs.djangoproject.com/en/2.1/ref/settings/
 """
 
 import os
+from rest_framework.authentication import BasicAuthentication
+from rest_framework.permissions import DjangoObjectPermissions
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -40,7 +42,8 @@ INSTALLED_APPS = [
     'django_extensions',
     'webpack_loader',
     'open_widget_framework',
-    'open_widget_sample_app'
+    'open_widget_sample_app',
+    'guardian'
 ]
 
 MIDDLEWARE = [
@@ -74,6 +77,10 @@ TEMPLATES = [
 
 WSGI_APPLICATION = 'open_widget_sample_app.wsgi.application'
 
+AUTHENTICATION_BACKENDS = (
+    'django.contrib.auth.backends.ModelBackend',
+    'guardian.backends.ObjectPermissionBackend',
+)
 
 # Database
 # https://docs.djangoproject.com/en/2.1/ref/settings/#databases
@@ -143,4 +150,8 @@ WEBPACK_LOADER = {
 
 CORS_ORIGIN_ALLOW_ALL = True
 
-SITE_BASE_URL = 'http://127.0.0.1:8000/api/v1/'
+WIDGET_FRAMEWORK = {
+    'WIDGET_FRAMEWORK_AUTHENTICATION_CLASSES': (BasicAuthentication,),
+    'WIDGET_FRAMEWORK_PERMISSION_CLASSES': (DjangoObjectPermissions,),
+    'WIDGET_LIST_EDIT_PERMISSIONS': ['change_widgetlist']
+}

--- a/open_widget_sample_app/views.py
+++ b/open_widget_sample_app/views.py
@@ -1,16 +1,8 @@
-
-from django.conf import settings
 from django.shortcuts import render
-from django.views.decorators.csrf import csrf_exempt
 
 
-@csrf_exempt
 def index(request):
     """
     Renders the home page which enables the single page sample react app
     """
-    context = {
-        'site_url': settings.SITE_BASE_URL
-    }
-
-    return render(request, 'open_widget_sample_app/index.html', context=context)
+    return render(request, 'open_widget_sample_app/index.html')

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "test:watch": "nwb test-react --server"
   },
   "dependencies": {
-    "@zagaran/open-widget-framework": "^0.2.29",
+    "@babel/plugin-proposal-class-properties": "^7.1.0",
+    "@zagaran/open-widget-framework": "^0.2.33",
     "lodash.range": "^3.2.0",
     "nwb": "^0.23.0",
     "octicons": "^8.1.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test:watch": "nwb test-react --server"
   },
   "dependencies": {
-    "@zagaran/open-widget-framework": "^0.2.11",
+    "@zagaran/open-widget-framework": "^0.2.25",
     "lodash.range": "^3.2.0",
     "octicons": "^8.1.0",
     "react": "^16.5.2",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test:watch": "nwb test-react --server"
   },
   "dependencies": {
-    "@zagaran/open-widget-framework": "^0.1.21",
+    "@zagaran/open-widget-framework": "^0.2.11",
     "lodash.range": "^3.2.0",
     "octicons": "^8.1.0",
     "react": "^16.5.2",

--- a/package.json
+++ b/package.json
@@ -12,8 +12,9 @@
     "test:watch": "nwb test-react --server"
   },
   "dependencies": {
-    "@zagaran/open-widget-framework": "^0.2.27",
+    "@zagaran/open-widget-framework": "^0.2.29",
     "lodash.range": "^3.2.0",
+    "nwb": "^0.23.0",
     "octicons": "^8.1.0",
     "react": "^16.5.2",
     "react-component-octicons": "^1.8.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test:watch": "nwb test-react --server"
   },
   "dependencies": {
-    "@zagaran/open-widget-framework": "^0.2.25",
+    "@zagaran/open-widget-framework": "^0.2.27",
     "lodash.range": "^3.2.0",
     "octicons": "^8.1.0",
     "react": "^16.5.2",

--- a/requirements.in
+++ b/requirements.in
@@ -6,3 +6,4 @@ ipython
 psycopg2
 django-cors-headers
 open-widget-framework
+django-guardian

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,14 +9,14 @@ click==7.0                # via pip-tools
 decorator==4.3.0          # via ipython, traitlets
 django-cors-headers==2.4.0
 django-extensions==2.1.3
-django-rest-framework==0.1.0  # via open-widget-framework
+django-guardian==1.4.9
 django-webpack-loader==0.6.0
 django==2.1.2
-djangorestframework==3.9.0  # via django-rest-framework
+djangorestframework==3.9.0  # via open-widget-framework
 ipython-genutils==0.2.0   # via traitlets
 ipython==7.1.1
 jedi==0.13.1              # via ipython
-open-widget-framework==0.1.8
+open-widget-framework==0.2.0
 parso==0.3.1              # via jedi
 pexpect==4.6.0            # via ipython
 pickleshare==0.7.5        # via ipython
@@ -26,6 +26,6 @@ psycopg2==2.7.5
 ptyprocess==0.6.0         # via pexpect
 pygments==2.2.0           # via ipython
 pytz==2018.7              # via django
-six==1.11.0               # via django-extensions, pip-tools, prompt-toolkit, traitlets
+six==1.11.0               # via django-extensions, django-guardian, pip-tools, prompt-toolkit, traitlets
 traitlets==4.3.2          # via ipython
 wcwidth==0.1.7            # via prompt-toolkit

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ djangorestframework==3.9.0  # via open-widget-framework
 ipython-genutils==0.2.0   # via traitlets
 ipython==7.1.1
 jedi==0.13.1              # via ipython
-open-widget-framework==0.2.0
+open-widget-framework==0.2.1
 parso==0.3.1              # via jedi
 pexpect==4.6.0            # via ipython
 pickleshare==0.7.5        # via ipython

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ djangorestframework==3.9.0  # via open-widget-framework
 ipython-genutils==0.2.0   # via traitlets
 ipython==7.1.1
 jedi==0.13.1              # via ipython
-open-widget-framework==0.2.7
+open-widget-framework==0.2.12
 parso==0.3.1              # via jedi
 pexpect==4.6.0            # via ipython
 pickleshare==0.7.5        # via ipython

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ djangorestframework==3.9.0  # via open-widget-framework
 ipython-genutils==0.2.0   # via traitlets
 ipython==7.1.1
 jedi==0.13.1              # via ipython
-open-widget-framework==0.2.1
+open-widget-framework==0.2.7
 parso==0.3.1              # via jedi
 pexpect==4.6.0            # via ipython
 pickleshare==0.7.5        # via ipython

--- a/src/home.js
+++ b/src/home.js
@@ -3,7 +3,7 @@ import {BrowserRouter as Router, Link, Route} from 'react-router-dom'
 import Octicon from 'react-component-octicons'
 import WidgetList from '@zagaran/open-widget-framework/es/widget_list'
 import { ModalFormWrapper, ConfirmDeleteWidgetWrapper, HighlightEditListWrapper } from "./wrappers";
-import { configureWidgetFrameworkSettings } from '@zagaran/open-widget-framework/es/config'
+import { defaultSettings } from '@zagaran/open-widget-framework/es/config'
 
 import {apiPath} from '@zagaran/open-widget-framework/es/utils'
 
@@ -21,11 +21,12 @@ class Home extends Component {
     super(props)
     this.state = {
       widgetLists: null,
-      ...configureWidgetFrameworkSettings({
+      mySettings: {
         // FormWrapper: ModalFormWrapper,
         // WidgetWrapper: ConfirmDeleteWidgetWrapper,
         // ListWrapper: HighlightEditListWrapper,
-      })
+      },
+      ...defaultSettings,
     }
     this.updateLists = this.updateLists.bind(this)
     this.addList = this.addList.bind(this)
@@ -79,7 +80,7 @@ class Home extends Component {
           <div className={'widget-home'}>
             <Route path='/list/:widgetListId' render={({match}) => (
               <WidgetList widgetListId={match.params.widgetListId}
-                          {...this.state}
+                          {...this.state.mySettings}
               />
             )}/>
             <div className={'widget-list-navigator container'}>

--- a/src/home.js
+++ b/src/home.js
@@ -1,4 +1,3 @@
-import {hot} from 'react-hot-loader'
 import React, {Component} from 'react'
 import {BrowserRouter as Router, Link, Route} from 'react-router-dom'
 import Octicon from 'react-component-octicons'
@@ -71,9 +70,9 @@ class Home extends Component {
     /**
      * Render background list of available widget lists and one WidgetList specified in the route using react-router
      */
-    const { widgetLists, loader } = this.state
+    const { widgetLists, Loader } = this.state
     if (widgetLists === null) {
-      return (loader)
+      return <Loader/>
     } else {
       return (
         <Router>
@@ -107,4 +106,4 @@ class Home extends Component {
   }
 }
 
-export default hot(module)(Home)
+export default Home

--- a/src/home.js
+++ b/src/home.js
@@ -17,20 +17,14 @@ class Home extends Component {
    *    fetchRoute: where to widget lists from
    *    baseUrl: the base url to build api endpoints off of
    */
-  constructor(props) {
-    super(props)
-    this.state = {
-      widgetLists: null,
-      mySettings: {
-        // FormWrapper: ModalFormWrapper,
-        // WidgetWrapper: ConfirmDeleteWidgetWrapper,
-        // ListWrapper: HighlightEditListWrapper,
-      },
-      ...defaultSettings,
-    }
-    this.updateLists = this.updateLists.bind(this)
-    this.addList = this.addList.bind(this)
-    this.deleteList = this.deleteList.bind(this)
+  state = {
+    widgetLists: null,
+    mySettings: {
+      // FormWrapper: ModalFormWrapper,
+      // WidgetWrapper: ConfirmDeleteWidgetWrapper,
+      // ListWrapper: HighlightEditListWrapper,
+    },
+    ...defaultSettings,
   }
 
   componentDidMount() {
@@ -39,31 +33,34 @@ class Home extends Component {
      */
     const { fetchData, errorHandler } = this.state
     fetchData(apiPath('get_lists'))
-      .then(this.updateLists)
+      .then(data => { this.setState({widgetLists: data.map(widgetList => widgetList.id)}) })
       .catch(errorHandler)
   }
 
-  updateLists(data) {
-    this.setState({widgetLists: data})
-  }
-
-  addList() {
+  addList = () => {
     /**
      * Make request to create new widget list
      */
-    const { fetchData, errorHandler } = this.state
+    const { fetchData, errorHandler, widgetLists } = this.state
     fetchData(apiPath('widget_list'), {method: 'POST'})
-      .then(this.updateLists)
+      .then(data => {
+        widgetLists.push(data.id)
+        this.setState({widgetLists: widgetLists})
+      })
       .catch(errorHandler)
   }
 
-  deleteList(listId) {
+  deleteList = (listId) => {
     /**
      * Make request to delete widget list
+     * NOTE: we just use fetch here because the DELETE method doesn't return json data
      */
-    const { fetchData, errorHandler } = this.state
-    fetchData(apiPath('widget_list', listId), {method: 'DELETE'})
-      .then(this.updateLists)
+    const { errorHandler, widgetLists } = this.state
+    fetch(apiPath('widget_list', listId), {method: 'DELETE'})
+      .then(() => {
+        widgetLists.splice(widgetLists.indexOf(listId), 1)
+        this.setState({widgetLists: widgetLists})
+      })
       .catch(errorHandler)
   }
 

--- a/src/home.js
+++ b/src/home.js
@@ -2,26 +2,31 @@ import {hot} from 'react-hot-loader'
 import React, {Component} from 'react'
 import {BrowserRouter as Router, Link, Route} from 'react-router-dom'
 import Octicon from 'react-component-octicons'
-import WidgetList from '@zagaran/open-widget-framework/es/widget-list'
-import {MyListWrapper, MyWidgetWrapper} from "./wrappers";
-import configureWidgetFrameworkSettings from '@zagaran/open-widget-framework/es/config'
+import WidgetList from '@zagaran/open-widget-framework/es/widget_list'
+import { ModalFormWrapper, ConfirmDeleteWidgetWrapper, HighlightEditListWrapper } from "./wrappers";
+import { configureWidgetFrameworkSettings } from '@zagaran/open-widget-framework/es/config'
 
 import {apiPath} from '@zagaran/open-widget-framework/es/utils'
 
-/**
- * Home is the home page of the sample widget-framework app. It renders a list of widget lists and one specified
- * widget list
- *
- * Props:
- *    fetchRoute: where to widget lists from
- *    baseUrl: the base url to build api endpoints off of
- */
+
 class Home extends Component {
+  /**
+   * Home is the home page of the sample widget-framework app. It renders a list of widget lists and one specified
+   * widget list
+   *
+   * Props:
+   *    fetchRoute: where to widget lists from
+   *    baseUrl: the base url to build api endpoints off of
+   */
   constructor(props) {
     super(props)
     this.state = {
       widgetLists: null,
-      widgetFrameworkSettings: configureWidgetFrameworkSettings()
+      ...configureWidgetFrameworkSettings({
+        // FormWrapper: ModalFormWrapper,
+        // WidgetWrapper: ConfirmDeleteWidgetWrapper,
+        // ListWrapper: HighlightEditListWrapper,
+      })
     }
     this.updateLists = this.updateLists.bind(this)
     this.addList = this.addList.bind(this)
@@ -32,46 +37,50 @@ class Home extends Component {
     /**
      * Fetch data on widget lists from fetchRoute
      */
-    this.state.widgetFrameworkSettings.fetchData(apiPath('get_lists'))
+    const { fetchData, errorHandler } = this.state
+    fetchData(apiPath('get_lists'))
       .then(this.updateLists)
-      .catch(this.state.widgetFrameworkSettings.errorHandler)
+      .catch(errorHandler)
   }
 
   updateLists(data) {
-    this.setState({widgetLists: data.map(obj => obj.id)})
+    this.setState({widgetLists: data})
   }
 
   addList() {
     /**
      * Make request to create new widget list
      */
-    this.state.widgetFrameworkSettings.fetchData(apiPath('widget_list'), {method: 'POST'})
+    const { fetchData, errorHandler } = this.state
+    fetchData(apiPath('widget_list'), {method: 'POST'})
       .then(this.updateLists)
-      .catch(this.state.widgetFrameworkSettings.errorHandler)
+      .catch(errorHandler)
   }
 
   deleteList(listId) {
     /**
      * Make request to delete widget list
      */
-    this.state.widgetFrameworkSettings.fetchData(apiPath('widget_list', listId), {method: 'DELETE'})
+    const { fetchData, errorHandler } = this.state
+    fetchData(apiPath('widget_list', listId), {method: 'DELETE'})
       .then(this.updateLists)
-      .catch(this.state.widgetFrameworkSettings.errorHandler)
+      .catch(errorHandler)
   }
 
   render() {
     /**
      * Render background list of available widget lists and one WidgetList specified in the route using react-router
      */
-    if (this.state.widgetLists === null) {
-      return (this.state.widgetFrameworkSettings.loader)
+    const { widgetLists, loader } = this.state
+    if (widgetLists === null) {
+      return (loader)
     } else {
       return (
         <Router>
           <div className={'widget-home'}>
             <Route path='/list/:widgetListId' render={({match}) => (
               <WidgetList widgetListId={match.params.widgetListId}
-                          widgetFrameworkSettings={this.state.widgetFrameworkSettings}
+                          {...this.state}
               />
             )}/>
             <div className={'widget-list-navigator container'}>
@@ -80,7 +89,7 @@ class Home extends Component {
 
               <h2>Widget Lists</h2>
               <ul className={'mt-3'}>
-                {this.state.widgetLists.map(
+                {widgetLists.map(
                   (widgetListId) => <li className={''} key={widgetListId}>
                     <Link to={'/list/' + widgetListId}>Widget List {widgetListId}</Link>
                     <span className={'btn text-danger'} onClick={() => this.deleteList(widgetListId)}>
@@ -95,12 +104,6 @@ class Home extends Component {
         </Router>
       )
     }
-  }
-}
-
-class MyComponent extends Component {
-  render() {
-    return (<p>Here are the props</p>)
   }
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -11,12 +11,3 @@ body {
     position:
             relative;
 }
-
-#react .widget-home .widget-sidebar {
-    position: absolute;
-    width: 400px;
-    right: 0;
-    top: 0;
-    padding-top: 20px;
-    margin: 5px;
-}

--- a/src/index.css
+++ b/src/index.css
@@ -11,3 +11,9 @@ body {
     position:
             relative;
 }
+
+#react .widget-list {
+    width: 400px;
+    right: 0;
+    position: absolute;
+}

--- a/src/wrappers.js
+++ b/src/wrappers.js
@@ -1,95 +1,144 @@
 import React, {Component} from 'react'
 import ReactModal from 'react-modal'
+import Octicon from 'react-component-octicons'
 
-class MyListWrapper extends Component {
+
+class HighlightEditListWrapper extends Component {
   constructor(props) {
     super(props)
     this.state = {
-      addWidgetModeActive: false,
+      editMode: false,
+      addWidgetForm: false,
+      editWidgetForm: null,
     }
+    this.renderAddWidgetButton = this.renderAddWidgetButton.bind(this)
+    this.closeForm = this.closeForm.bind(this)
   }
 
-  renderAddWidgetModal() {
+  renderAddWidgetButton() {
     return (
-      <ReactModal className={'edit-widget-modal btn-group card-header'}
-                  isOpen={this.state.addWidgetModeActive}>
-        <form className='widget-modal-form'>
-          <div className='widget-form-group form-group'>
-            WidgetForm
-          </div>
-          <button className={'edit-widget-submit btn btn-primary'} type='submit'>Submit</button>
-        </form>
-      </ReactModal>
+      <button className={'btn btn-info col'} onClick={() => this.setState({
+        addWidgetForm: !this.state.addWidgetForm,
+        editWidgetForm: null,
+      })}>
+        New Widget
+      </button>
     )
   }
 
+  closeForm() {
+    this.setState({
+      addWidgetForm: false,
+      editWidgetForm: null,
+    })
+  }
+
   render() {
+    const { editWidgetForm, addWidgetForm } = this.state
+    const { renderEditWidgetForm, renderNewWidgetForm, renderList } = this.props
     return (
-      <div>
-        <div className={'edit-widget-list-bar btn-group'} role={'group'}>
-          <button className={'btn btn-info'} onClick={this.setState({addWidgetModeActive: true})}>
-            Add a new widget
-          </button>
-          {this.renderAddWidgetModal()}
-        </div>
+      <div className={'col-lg-4 float-right m-8 '}>
+        <p>This list will highlight the widget that is currently being edited. It's defined in HighlightEditListWrapper</p>
+        {addWidgetForm ? renderNewWidgetForm({
+          closeForm: this.closeForm,
+          listPropClassNames: 'text-success border border-success rounded'
+        }) : null}
+        {editWidgetForm !== null
+          ? renderEditWidgetForm(editWidgetForm, {
+          closeForm: this.closeForm,
+          listPropClassNames: 'text-info border border-info rounded'
+        }) : null}
+        {renderList({
+          editWidget: widgetId => this.setState({
+            editWidgetForm: widgetId,
+            addWidgetForm: false,
+          }),
+          highlightedWidget: editWidgetForm,
+        })}
         <hr/>
-        <div>
-          {this.props.renderList()}
-        </div>
+        {this.renderAddWidgetButton()}
       </div>
     )
   }
 }
 
-class MyWidgetWrapper extends Component {
-  constructor(props) {
-    super(props)
-    this.state = {
-      editWidgetModeActive: false,
-      newWidgetPosition: null,
-    }
-  }
-
-  onSubmit(event) {
-    event.preventDefault()
-    this.props.moveWidget(this.state.newWidgetPosition)
-  }
-
-  renderEditModal() {
+class ConfirmDeleteWidgetWrapper extends Component {
+  renderMoveWidgetBar() {
+    const { position, listLength, moveWidget } = this.props
     return (
-      <ReactModal className={'edit-widget-modal btn-group card-header'}
-                  isOpen={this.state.editWidgetModeActive}>
-        <form className='widget-modal-form container'>
-          <div className='widget-form-group form-group'>
-            <label className='widget-form-label'
-                   htmlFor={'widget-position-input'}>
-              Set widget position
-            </label>
-            <input type={'number'} onChange={(event) => this.setState({newWidgetPosition: event.target.value})}/>
-          </div>
-          <button className={'edit-widget-submit btn btn-primary'} type='submit'>Submit</button>
-          <button className={'delete-widget btn btn-primary'} onClick={this.props.deleteWidget}>Delete</button>
-          <button className={'cancel-widget btn btn-primary'} onClick={this.setState({editWidgetModeActive: false})}>
-            Cancel
-          </button>
-        </form>
-      </ReactModal>
+      <div className={'reposition-widget-bar btn-group-vertical col-lg-3'}>
+        <button className={'btn btn-light'}
+                disabled={position === 0}
+                onClick={() => moveWidget(0)}
+                title={'Move widget to top'}>
+          <Octicon zoom="x2" name={'triangle-up'} />
+        </button>
+        <button className={'btn btn-light'}
+                disabled={position === 0}
+                onClick={() => moveWidget(position - 1)}
+                title={'Move widget up one position'}>
+          <Octicon zoom="x2" name={'chevron-up'}/>
+        </button>
+        <button className={'btn btn-light'}
+                disabled={position === listLength - 1}
+                onClick={() => moveWidget(position + 1)}
+                title={'Move widget down one position'}>
+          <Octicon zoom="x2" name={'chevron-down'}/>
+        </button>
+        <button className={'btn btn-light'}
+                disabled={position === listLength - 1}
+                onClick={() => moveWidget(listLength - 1)}
+                title={'Move widget to bottom'}>
+          <Octicon zoom="x2" name={'triangle-down'}/>
+        </button>
+      </div>
     )
   }
 
   render() {
+    const { deleteWidget, editWidget, id, listPropClassNames, highlightedWidget, renderWidget } = this.props
     return (
-      <div className={'widget card mb-3 bg-light'}>
-        <button className={'btn btn-info col'}
-                onClick={() => this.setState({editWidgetModeActive: !this.state.editWidgetModeActive})}
-                title={'Open edit widget modal'}>
-          Edit Widget
-        </button>
-        {this.renderEditModal()}
-        {this.props.renderWidget()}
+      <div className={'widget-wrapper row mb-3 p-3 rounded ' + (highlightedWidget === id ? 'bg-primary' : 'bg-secondary')}>
+        {this.renderMoveWidgetBar()}
+        <div className={'widget-main col-lg-9'}>
+          <div className={'edit-delete-widget-bar btn-group col'}>
+            <button className={'btn btn-primary col'} onClick={() => editWidget(id)}
+                    title={'Update widget'}>
+              <Octicon zoom="x2" name={'pencil'}/>
+            </button>
+            <button className={'btn btn-danger col'}
+                    onClick={() => {if (confirm('Are you sure you want to delete this widget?')) {deleteWidget(id)}}}
+                    title={'Delete widget'}>
+              <Octicon zoom="x2" name={'x'}/>
+            </button>
+          </div>
+          <div className={'widget bg-light mt-3 rounded'}>
+            {renderWidget()}
+          </div>
+        </div>
+        <p>These buttons are created in the ConfirmDeleteWidgetWrapper</p>
+        <p className={listPropClassNames}>This message is styled by HighlightEditListWrapper</p>
       </div>
     )
   }
 }
 
-export {MyListWrapper, MyWidgetWrapper}
+class ModalFormWrapper extends Component {
+  render() {
+    const { closeForm, renderForm, updateWidgetList, listPropClassNames } = this.props
+    return (
+      <ReactModal isOpen={true} onRequestClose={closeForm} className='widget-form-modal container mt-4 col-lg-4'>
+        <p className={'text-primary'}>This modal is created in the ModalFormWrapper</p>
+        <p className={listPropClassNames}>This message is styled by HighlightEditListWrapper</p>
+        {renderForm({
+          onSubmit: data => {
+            updateWidgetList(data)
+            closeForm()
+          },
+        })}
+      </ReactModal>
+    )
+  }
+}
+
+export { ModalFormWrapper, ConfirmDeleteWidgetWrapper, HighlightEditListWrapper }

--- a/src/wrappers.js
+++ b/src/wrappers.js
@@ -38,7 +38,9 @@ class HighlightEditListWrapper extends Component {
     const { renderEditWidgetForm, renderNewWidgetForm, renderList } = this.props
     return (
       <div className={'col-lg-4 float-right m-8 '}>
-        <p>This list will highlight the widget that is currently being edited. It's defined in HighlightEditListWrapper</p>
+        <p>
+          This list will highlight the widget that is currently being edited. It's defined in HighlightEditListWrapper
+        </p>
         {addWidgetForm ? renderNewWidgetForm({
           closeForm: this.closeForm,
           listPropClassNames: 'text-success border border-success rounded'

--- a/src/wrappers.js
+++ b/src/wrappers.js
@@ -39,7 +39,7 @@ class HighlightEditListWrapper extends Component {
     return (
       <div className={'col-lg-4 float-right m-8 '}>
         <p>
-          This list will highlight the widget that is currently being edited. Its defined in HighlightEditListWrapper
+          This list will highlight the widget that is currently being edited. It's defined in HighlightEditListWrapper
         </p>
         {addWidgetForm ? renderNewWidgetForm({
           closeForm: this.closeForm,

--- a/src/wrappers.js
+++ b/src/wrappers.js
@@ -39,7 +39,7 @@ class HighlightEditListWrapper extends Component {
     return (
       <div className={'col-lg-4 float-right m-8 '}>
         <p>
-          This list will highlight the widget that is currently being edited. It's defined in HighlightEditListWrapper
+          This list will highlight the widget that is currently being edited. Its defined in HighlightEditListWrapper
         </p>
         {addWidgetForm ? renderNewWidgetForm({
           closeForm: this.closeForm,


### PR DESCRIPTION
This PR addresses Issue #11 in open-widget-framework

I added three wrappers, one for each react component. You can turn them on or off at will from the home.js file (just comment out the line in the configure settings function). Any combination of them will render, but not all the functionality is present if you turn on the list wrapper but not the widget wrapper. 

Between these and the default wrappers you should have a decent set of examples on how props can be passed between wrappers and how the list can be manipulated within the wrappers.

Next is documentation